### PR TITLE
Bump python version requirements from 3.6 to 3.7

### DIFF
--- a/docs/ko/source/installation/index.rst
+++ b/docs/ko/source/installation/index.rst
@@ -14,7 +14,7 @@ SDK 설치를 위한 최소 요구사항
   * Ubuntu 18.04 LTS (Bionic Beaver) 또는 Debian buster
     또는 상위 버전
   * 시스템의 관리자 권한 (root)
-  * Python 3.6+
+  * Python 3.7+
   * GitHub 및 PyPi 로 연결 가능한 네트워크 환경
   * onnxruntime 1.6.0 (모델 quantization & calibration, NPU 에서 지원하지 않는 오퍼레이터 처리를 위해 설치 필요)
 
@@ -32,7 +32,7 @@ SDK 구성 요소별 설치 안내
 
   * :doc:`FuriosaAI NPU Python SDK 설치 [Required]<python-sdk>` : NPU 사용을 위한 Python 라이브러리 및 명령도구 (cli)
 
-    * :doc:`FuriosaAI NPU Python SDK 설치를 위한 Python 환경 구성 [Optional]<python-sdk-setup-python>` : FuriosaAI NPU Python SDK 설치를 위한 Python 3.6+ 환경 구성 안내
+    * :doc:`FuriosaAI NPU Python SDK 설치를 위한 Python 환경 구성 [Optional]<python-sdk-setup-python>` : FuriosaAI NPU Python SDK 설치를 위한 Python 3.7+ 환경 구성 안내
 
   * :doc:`FuriosaAI API 키 설정 [Optional]<apikey>` : FuriosaAI에서 웹 서비스로 제공하는 도구를 사용하기 위한 설정
 

--- a/docs/ko/source/installation/python-sdk-setup-python.rst
+++ b/docs/ko/source/installation/python-sdk-setup-python.rst
@@ -1,5 +1,5 @@
 ********************************************************************
-FuriosaAI NPU Python SDK 설치를 위한 Python 3.6+ 환경 구성
+FuriosaAI NPU Python SDK 설치를 위한 Python 3.7+ 환경 구성
 ********************************************************************
 
 
@@ -37,7 +37,7 @@ Anaconda를 이용한 Python 환경 구성
 
 
 Anaconda 설치 후에는 독립된 환경을 셋업하고 필요에 따라 활성화 할 수 있다.
-FuriosaAI Python SDK는 Python 3.6-3.8 버전과 호환된다. 따라서 python 3.8 새로운 환경을
+FuriosaAI Python SDK는 Python 3.7-3.8 버전과 호환된다. 따라서 python 3.8 새로운 환경을
 ``furiosa`` 라는 이름으로 생성한다.
 
 .. code-block::

--- a/docs/ko/source/installation/python-sdk.rst
+++ b/docs/ko/source/installation/python-sdk.rst
@@ -12,7 +12,7 @@ FuriosaAI NPU Python SDK 는 모델을 NPU 에서 가속시키기 위한 각종 
 
 요구 사항
 ----------------------------------------
-* Pyrhon 3.6+
+* Pyrhon 3.7+
 
   * :doc:`./python-sdk-setup-python`
 

--- a/docs/ko/source/quickstart/index.rst
+++ b/docs/ko/source/quickstart/index.rst
@@ -9,7 +9,7 @@ FuriosaAI NPU Python SDK 라이브러리를 사용하면 NPU 를 사용하는 �
 
 요구사항
 
-  * Python 3.6+
+  * Python 3.7+
 
     * :doc:`/installation/python-sdk-setup-python`
 


### PR DESCRIPTION
capture_output 파라미터가 3.6에 없습니다.