### PR TITLE
image_segmentation example should write the output into the current directory.

### DIFF
--- a/docs/en/source/installation/python-sdk.rst
+++ b/docs/en/source/installation/python-sdk.rst
@@ -25,13 +25,13 @@ of command line tools and functions. The FuriosaAI Python SDK can be installed w
 .. code-block:: sh
 
   # Install the FuriosaAI NPU Python SDK to use the Python interface, e.g. `import furiosa`
-  pip install --upgrade furiosa-sdk~=0.1.0
+  pip install --upgrade furiosa-sdk
   # Install additional tools, see below for details
-  pip install --upgrade furiosa-sdk[runtime,quantizer]~=0.1.0
+  pip install --upgrade furiosa-sdk[runtime,quantizer]
   # Install all additional tools
-  pip install --upgrade furiosa-sdk[full]~=0.1.0
+  pip install --upgrade furiosa-sdk[full]
 
-The following additional packages can be installed by using pip. 
+The following additional packages can be installed by using pip.
 
 * ``cli``: Installs the command line tool. Refer to :doc:`/quickstart/cli` for usage
 
@@ -43,40 +43,40 @@ The following additional packages can be installed by using pip.
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[runtime]~=0.1.0
+    pip install --upgrade furiosa-sdk[runtime]
 
 * ``quantizer``: Installs the model quantization tool (see :doc:`/advanced/quantization`)
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[quantizer]~=0.1.0
+    pip install --upgrade furiosa-sdk[quantizer]
 
 * ``validator``: Installs model analysis tools, quantizes for accelerating corresponding models on the NPU, and includes compilation success verification tools.
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[quantizer,runtime,validator,cli]~=0.1.0
+    pip install --upgrade furiosa-sdk[quantizer,runtime,validator,cli]
 
 
 If you need a development environment for model inference and model quantization tools, the following installs them for you:
 
 .. code-block:: sh
 
-  pip install --upgrade furiosa-sdk[runtime,quantizer]~=0.1.0
+  pip install --upgrade furiosa-sdk[runtime,quantizer]
 
 
 Jupyter Notebook User Guide
 ----------------------------------------
 
-While using Jupyter Notebook, you can leverage the FuriosaAI Python SDK 
+While using Jupyter Notebook, you can leverage the FuriosaAI Python SDK
 and various libraries in the Python ecosystem.
 
-If you have already installed the Python SDK as above, you can just install 
+If you have already installed the Python SDK as above, you can just install
 and use Jupyter Notebook using pip as shown below.
 Because Jupyter Notebook installs a wide variety of dependencies,
 :ref:`CondaInstall` is recommended.
 
 .. code-block:: sh
-  
+
   $ pip install jupyterlab
   $ jupyter-notebook

--- a/docs/ko/source/installation/python-sdk.rst
+++ b/docs/ko/source/installation/python-sdk.rst
@@ -25,11 +25,11 @@ Python 라이브러리 인터페이스 이외에도 명령 줄 도구 및 다양
 .. code-block:: sh
 
   # FuriosaAI NPU Python SDK 설치, Python 인터페이스 사용 가능, e.g. `import furiosa`
-  pip install --upgrade furiosa-sdk~=0.1.0
+  pip install --upgrade furiosa-sdk
   # 부가 도구 설치, 자세한 목록은 아래 참조
-  pip install --upgrade furiosa-sdk[runtime,quantizer]~=0.1.0
+  pip install --upgrade furiosa-sdk[runtime,quantizer]
   # 부가 도구 전체 설치
-  pip install --upgrade furiosa-sdk[full]~=0.1.0
+  pip install --upgrade furiosa-sdk[full]
 
 PIP 커맨드를 이용하여 다음 부가 패키지를 설치할 수 있다.
 
@@ -43,26 +43,26 @@ PIP 커맨드를 이용하여 다음 부가 패키지를 설치할 수 있다.
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[runtime]~=0.1.0
+    pip install --upgrade furiosa-sdk[runtime]
 
 * ``quantizer``: 모델의 양자화 도구 설치 (:doc:`/advanced/quantization` 참고)
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[quantizer]~=0.1.0
+    pip install --upgrade furiosa-sdk[quantizer]
 
 * ``validator``: 모델 분석 도구 설치, 해당 모델이 NPU 위에서 가속되기 위해 양자화, 컴파일이 잘 수행되는지 확인하는 도구를 포함
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[quantizer,runtime,validator,cli]~=0.1.0
+    pip install --upgrade furiosa-sdk[quantizer,runtime,validator,cli]
 
 
 예를 들어 모델 추론을 위한 개발환경과 모델 양자화 도구가 필요한 경우 아래와 같이 설치한다.
 
 .. code-block:: sh
 
-  pip install --upgrade furiosa-sdk[runtime,quantizer]~=0.1.0
+  pip install --upgrade furiosa-sdk[runtime,quantizer]
 
 
 Jupyter Notebook 사용 안내
@@ -72,12 +72,12 @@ Jupyter Notebook을 사용하는 경우
 FuriosaAI Python SDK와 다양한 Python 생태계의 다양한
 라이브러리를 편하게 사용할 수 있다.
 
-위 설명에 따라 Python SDK를 이미 설치했다면 
+위 설명에 따라 Python SDK를 이미 설치했다면
 아래와 같이 pip를 이용해 Jupyter notebook을 간단히 설치해 사용할 수 있다.
 Jupyter notebook은 아주 다양한 의존된 패키지를 설치하기 때문에
 :ref:`CondaInstall` 을 권장한다.
 
 .. code-block:: sh
-  
+
   $ pip install jupyterlab
   $ jupyter-notebook

--- a/examples/furiosa-sdk-runtime/image_segmentation.py
+++ b/examples/furiosa-sdk-runtime/image_segmentation.py
@@ -62,12 +62,11 @@ def run_segmentation(image_path: str, model_path: str, is_fp32: bool) -> None:
     input_image = Image.open(image_path)
     input_array = preprocess(input_image, (height, width))
 
-    start_time = time.time()
-
     if is_fp32:
         # ONNX runtime inference with the given FP32 model
         ort.set_default_logger_severity(3)
         sess = ort.InferenceSession(model_path)
+        start_time = time.time()
         output_tensor = sess.run(['out'], input_feed={'input': np.expand_dims(input_array, axis=0)})[0]
         rgb = decode_segmap(output_tensor.squeeze())
     else:
@@ -76,6 +75,7 @@ def run_segmentation(image_path: str, model_path: str, is_fp32: bool) -> None:
             print("Model has been compiled successfully")
             print("Model input and output:")
             print(sess.print_summary())
+            start_time = time.time()
             output_tensor = sess.run(np.expand_dims(input_array, axis=0))
             output_tensor = output_tensor[0].numpy()
             np_array = np.squeeze(output_tensor)

--- a/examples/furiosa-sdk-runtime/image_segmentation.py
+++ b/examples/furiosa-sdk-runtime/image_segmentation.py
@@ -7,6 +7,7 @@ import sys
 import time
 import numpy as np
 import onnxruntime as ort
+import os
 
 from typing import Tuple
 from PIL import Image
@@ -90,8 +91,8 @@ def run_segmentation(image_path: str, model_path: str, is_fp32: bool) -> None:
     composite_image = Image.composite(input_image, output_image, mask)
     result_image.paste(composite_image)
     result_image.paste(output_image, (input_image.width, 0))
-    result_image.save(f'{image_path.split(".")[0]}_result.jpg')
-    result_image.show()
+    result_image.save(f'{os.path.basename(image_path).split(".")[0]}_result.jpg')
+    print(f'{os.path.basename(image_path).split(".")[0]}_result.jpg has been written.')
 
 
 if __name__ == "__main__":

--- a/examples/furiosa-sdk-runtime/image_segmentation.py
+++ b/examples/furiosa-sdk-runtime/image_segmentation.py
@@ -27,7 +27,7 @@ def preprocess(img: Image.Image, size: Tuple[int, int]) -> np.array:
 
     img_arr = img_arr.transpose([2, 0, 1])
 
-    return np.ascontiguousarray(img_arr)
+    return img_arr
 
 
 def decode_segmap(image: np.array) -> np.array:

--- a/python/furiosa-sdk-runtime/furiosa_sdk_runtime/tensor.py
+++ b/python/furiosa-sdk-runtime/furiosa_sdk_runtime/tensor.py
@@ -147,6 +147,8 @@ class Tensor:
 
     def copy_from(self, data: Union[np.ndarray, np.generic]):
         """Copy the contents of Numpy ndarray to this tensor"""
+        if isinstance(data, np.ndarray):
+            data = np.ascontiguousarray(data)
         if isinstance(data, (np.ndarray, np.generic)):
             buf_ptr = data.ctypes.data_as(POINTER(c_uint8))
             buf_size_in_bytes = data.nbytes


### PR DESCRIPTION
Python script가 GUI 환경을 전제한 `PLT.show()`을 사용하기 보다는 현재 디렉토리에 파일을 쓰고 파일명을 출력하는것이 다른 스크립트들과 일관성을 가지는 것 같아 변경했습니다. 또한 `ascontiguousarray()` 은 runtime이 내부적으로 해결하므로 image_segmentation 예제에서는 제거 했습니다. 그외 rebase 및 prediction time에서 컴파일 시간을 제거하였습니다.