### PR TITLE
Add quotes for pip install

### DIFF
--- a/docs/en/source/installation/prerequisites.rst
+++ b/docs/en/source/installation/prerequisites.rst
@@ -110,7 +110,7 @@ For more detailed instructions for installation, refer to  :doc:`/installation/p
 
 .. code-block::
 
-  $ pip install furiosa-sdk[cli, runtime]
+  $ pip install 'furiosa-sdk[cli, runtime]'
 
 
 To deactivate the use of the user created Python environment, use the ``deactivate`` command.

--- a/docs/en/source/installation/python-sdk.rst
+++ b/docs/en/source/installation/python-sdk.rst
@@ -27,9 +27,9 @@ of command line tools and functions. The FuriosaAI Python SDK can be installed w
   # Install the FuriosaAI NPU Python SDK to use the Python interface, e.g. `import furiosa`
   pip install --upgrade furiosa-sdk
   # Install additional tools, see below for details
-  pip install --upgrade furiosa-sdk[runtime,quantizer]
+  pip install --upgrade 'furiosa-sdk[runtime,quantizer]'
   # Install all additional tools
-  pip install --upgrade furiosa-sdk[full]
+  pip install --upgrade 'furiosa-sdk[full]'
 
 The following additional packages can be installed by using pip.
 
@@ -37,32 +37,32 @@ The following additional packages can be installed by using pip.
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[cli]
+    pip install --upgrade 'furiosa-sdk[cli]'
 
 * ``runtime``:  Installs various libraries to accelerating models using the NPU using the FuriosaAI NPU Runtime. **Required for model acceleration using the NPU**
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[runtime]
+    pip install --upgrade 'furiosa-sdk[runtime]'
 
 * ``quantizer``: Installs the model quantization tool (see :doc:`/advanced/quantization`)
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[quantizer]
+    pip install --upgrade 'furiosa-sdk[quantizer]'
 
 * ``validator``: Installs model analysis tools, quantizes for accelerating corresponding models on the NPU, and includes compilation success verification tools.
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[quantizer,runtime,validator,cli]
+    pip install --upgrade 'furiosa-sdk[quantizer,runtime,validator,cli]'
 
 
 If you need a development environment for model inference and model quantization tools, the following installs them for you:
 
 .. code-block:: sh
 
-  pip install --upgrade furiosa-sdk[runtime,quantizer]
+  pip install --upgrade 'furiosa-sdk[runtime,quantizer]'
 
 
 Jupyter Notebook User Guide

--- a/docs/en/source/quickstart/cli.rst
+++ b/docs/en/source/quickstart/cli.rst
@@ -19,7 +19,7 @@ Install Command Line Tools
 
 .. code-block:: sh
 
-  $ pip install furiosa-sdk[cli, validator]
+  $ pip install 'furiosa-sdk[cli, validator]'
 
 
 Verifying the Installation

--- a/docs/en/source/quickstart/python-sdk.rst
+++ b/docs/en/source/quickstart/python-sdk.rst
@@ -16,7 +16,7 @@ If the above requirements have been fulfilled, you can install the FuriosaAI NPU
 
 .. code-block:: sh
 
-  pip install --upgrade furiosa-sdk[runtime]~=0.1.0
+  pip install --upgrade 'furiosa-sdk[runtime]~=0.1.0'
 
 
 Running Basic Python Code

--- a/docs/ko/source/installation/prerequisites.rst
+++ b/docs/ko/source/installation/prerequisites.rst
@@ -111,7 +111,7 @@ FuriosaAI Python SDK는 Python 3.7-3.8 버전과 호환된다. 따라서 최신 
 
 .. code-block::
 
-  $ pip install furiosa-sdk[cli, runtime]
+  $ pip install 'furiosa-sdk[cli, runtime]'
 
 
 생성한 Python 환경의 사용을 비활성화하고 싶은 경우 ``deactivate`` 명령을 사용한다.

--- a/docs/ko/source/installation/python-sdk.rst
+++ b/docs/ko/source/installation/python-sdk.rst
@@ -27,9 +27,9 @@ Python 라이브러리 인터페이스 이외에도 명령 줄 도구 및 다양
   # FuriosaAI NPU Python SDK 설치, Python 인터페이스 사용 가능, e.g. `import furiosa`
   pip install --upgrade furiosa-sdk
   # 부가 도구 설치, 자세한 목록은 아래 참조
-  pip install --upgrade furiosa-sdk[runtime,quantizer]
+  pip install --upgrade 'furiosa-sdk[runtime,quantizer]'
   # 부가 도구 전체 설치
-  pip install --upgrade furiosa-sdk[full]
+  pip install --upgrade 'furiosa-sdk[full]'
 
 PIP 커맨드를 이용하여 다음 부가 패키지를 설치할 수 있다.
 
@@ -37,32 +37,32 @@ PIP 커맨드를 이용하여 다음 부가 패키지를 설치할 수 있다.
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[cli]
+    pip install --upgrade 'furiosa-sdk[cli]'
 
 * ``runtime``: FuriosaAI NPU Runtime 을 사용하여 NPU 위에서 모델을 가속시키기 위한 각종 라이브러리 설치, **NPU 위에서 모델 가속을 위해 필수**
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[runtime]
+    pip install --upgrade 'furiosa-sdk[runtime]'
 
 * ``quantizer``: 모델의 양자화 도구 설치 (:doc:`/advanced/quantization` 참고)
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[quantizer]
+    pip install --upgrade 'furiosa-sdk[quantizer]'
 
 * ``validator``: 모델 분석 도구 설치, 해당 모델이 NPU 위에서 가속되기 위해 양자화, 컴파일이 잘 수행되는지 확인하는 도구를 포함
 
   .. code-block::
 
-    pip install --upgrade furiosa-sdk[quantizer,runtime,validator,cli]
+    pip install --upgrade 'furiosa-sdk[quantizer,runtime,validator,cli]'
 
 
 예를 들어 모델 추론을 위한 개발환경과 모델 양자화 도구가 필요한 경우 아래와 같이 설치한다.
 
 .. code-block:: sh
 
-  pip install --upgrade furiosa-sdk[runtime,quantizer]
+  pip install --upgrade 'furiosa-sdk[runtime,quantizer]'
 
 
 Jupyter Notebook 사용 안내

--- a/docs/ko/source/quickstart/cli.rst
+++ b/docs/ko/source/quickstart/cli.rst
@@ -19,7 +19,7 @@ FuriosaAI SDK는 모델 컴파일 및 최적화, 모델 양자화를 돕는
 
 .. code-block:: sh
 
-  $ pip install furiosa-sdk[cli, validator]
+  $ pip install 'furiosa-sdk[cli, validator]'
 
 
 설치 확인

--- a/docs/ko/source/quickstart/python-sdk.rst
+++ b/docs/ko/source/quickstart/python-sdk.rst
@@ -16,7 +16,7 @@ FuriosaAI NPU Python SDK 라이브러리를 사용하면 NPU를 사용하는 프
 
 .. code-block:: sh
 
-  pip install --upgrade furiosa-sdk[runtime]~=0.1.0
+  pip install --upgrade 'furiosa-sdk[runtime]~=0.1.0'
 
 
 간단한 Python 코드 실행

--- a/python/furiosa-sdk/README.md
+++ b/python/furiosa-sdk/README.md
@@ -11,7 +11,7 @@ pip install furiosa-sdk
 
 You can install furiosa-sdk with extra packages (for example runtime, quantizer):
 ```sh
-pip install furiosa-sdk[runtime,quantizer]
+pip install 'furiosa-sdk[runtime,quantizer]'
 ```
 
 ### Extra packages


### PR DESCRIPTION
To avoid bracket globbing in some shells, add quotes for packages via pip install.

Fixes #33
