### PR TITLE
changed input range from int8 to uint8

### DIFF
--- a/examples/inferences/quickstart_example.py
+++ b/examples/inferences/quickstart_example.py
@@ -26,10 +26,10 @@ def run_example():
   print(input_meta)
   
   # Generate the random input tensor according to the input shape
-  input = np.random.randint(-128, 127, input_meta.shape(), dtype=np.int8)
+  input = np.random.randint(0, 255, input_meta.shape, dtype=np.uint8)
   
   # Run the inference
-  outputs = sess.run(input)
+  outputs = sess.run(input.astype(np.uint8))
   
   print("== Output ==")
   print(outputs)


### PR DESCRIPTION
### Problem
* The `quickstart_example.py` is failing to execute. Error below:
```
(base) furiosa@demo-server-1:~/sdk/furiosa-sdk/examples/inferences$ python quickstart_example.py 
libfuriosa_hal.so --- v2.0, built @ 9928508
Saving the compilation log into /home/furiosa/.local/state/furiosa/logs/compile-20230111150146-ab4ewv.log
Using furiosa-compiler 0.8.0 (rev: d9f0d7728 built at 2022-11-01T03:39:34Z)
2023-01-11T06:01:46.006184Z  INFO nux::npu: Npu (npu0pe0-1) is being initialized
2023-01-11T06:01:46.008088Z  INFO nux: NuxInner create with pes: [PeId(0)]
Inputs:
{0: TensorDesc(shape=(1, 28, 28, 1), dtype=UINT8, format=NHWC, size=784, len=784)}
Outputs:
{0: TensorDesc(shape=(1, 1, 1, 10), dtype=UINT8, format=NHWC, size=10, len=10)}
TensorDesc(shape=(1, 28, 28, 1), dtype=UINT8, format=NHWC, size=784, len=784)
Traceback (most recent call last):
  File "/home/furiosa/sdk/furiosa-sdk/examples/inferences/quickstart_example.py", line 40, in <module>
    run_example()
  File "/home/furiosa/sdk/furiosa-sdk/examples/inferences/quickstart_example.py", line 29, in run_example
    input = np.random.randint(-128, 127, input_meta.shape(), dtype=np.int8)
TypeError: 'tuple' object is not callable
2023-01-11T06:01:46.023977Z  INFO nux::npu: NPU (npu0pe0-1) has been destroyed
2023-01-11T06:01:46.024126Z  INFO nux::capi: session has been destroyed

```

Other pertinent info 
Silicon rev, B0
`furiosaclt info`output`

```
(yolo) furiosa@demo-server-1:~/sdk/pr/furiosa-sdk/examples/inferences$ furiosactl info
+------+--------+--------------------------------------+-----------------+-------+--------+--------------+---------+
| NPU  | Name   | UUID                                 | Firmware        | Temp. | Power  | PCI-BDF      | PCI-DEV |
+------+--------+--------------------------------------+-----------------+-------+--------+--------------+---------+
| npu0 | warboy | C887310D-4FEA-40B0-A5DF-BAC8F1E37BDB | v1.4.0, 9eee141 |  57°C | 2.29 W | 0000:18:00.0 | 509:0   |
+------+--------+--------------------------------------+-----------------+-------+--------+--------------+---------+

```
### Solution
Adjust the input range and corresponding datatypes.

```
(yolo) furiosa@demo-server-1:~/sdk/pr/furiosa-sdk/examples/inferences$ git diff
diff --git a/examples/inferences/quickstart_example.py b/examples/inferences/quickstart_example.py
index 183321f..9cd3c47 100644
--- a/examples/inferences/quickstart_example.py
+++ b/examples/inferences/quickstart_example.py
@@ -26,10 +26,10 @@ def run_example():
   print(input_meta)
   
   # Generate the random input tensor according to the input shape
-  input = np.random.randint(-128, 127, input_meta.shape(), dtype=np.int8)
+  input = np.random.randint(0, 255, input_meta.shape, dtype=np.uint8)
   
   # Run the inference
-  outputs = sess.run(input)
+  outputs = sess.run(input.astype(np.uint8))
   
   print("== Output ==")
   print(outputs)

```


### Testing
Testing is not exhaustive. Execution now completes successfully. 

### Checklist
- [ ] Will this be part of a product update? If yes, please update [Changelog](https://github.com/furiosa-ai/furiosa-sdk-private/blob/main/CHANGELOG.md).
- [ ] Changes are less than 1000 lines (refer to [Pull Request 크기 줄이는 법](https://github.com/furiosa-ai/npu-tools/blob/master/CodingConvention.md#pull-request-%ED%81%AC%EA%B8%B0-%EC%A4%84%EC%9D%B4%EB%8A%94-%EB%B2%95))
- [ ] My code has passed black/isort.
- [ ] I have performed a self-review of my code.
- [ ] All CI checks have passed.
