### PR TITLE
changed 'compiler_config' to 'compile_config' to match parameter in n=3 places, otherwise compile fails

### DIFF
--- a/examples/notebooks/YOLOX-L.ipynb
+++ b/examples/notebooks/YOLOX-L.ipynb
@@ -133,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 10,
    "id": "ae8af1c9",
    "metadata": {},
    "outputs": [],
@@ -143,18 +143,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 11,
    "id": "3c40a9c0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "libfuriosa_hal.so --- v2.0, built @ 137e868\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import glob\n",
     "from itertools import islice\n",
@@ -186,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 12,
    "id": "670e87fa",
    "metadata": {},
    "outputs": [],
@@ -212,7 +204,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 13,
    "id": "18886593",
    "metadata": {},
    "outputs": [],
@@ -254,7 +246,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 14,
    "id": "390a8129",
    "metadata": {},
    "outputs": [],
@@ -275,7 +267,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 15,
    "id": "62d5eef9",
    "metadata": {},
    "outputs": [
@@ -283,8 +275,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Calibration: 100 samples [00:39,  2.55 samples/s]\n",
-      "Quantization: 100%|██████████████████████████████████████| 437/437 [00:02<00:00, 158.47 operators/s]\n"
+      "Calibration: 100 samples [00:37,  2.64 samples/s]\n",
+      "Quantization: 100%|██████████| 437/437 [00:04<00:00, 96.66 operators/s] \n"
      ]
     }
    ],
@@ -311,7 +303,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 16,
    "id": "d9c6c887",
    "metadata": {},
    "outputs": [],
@@ -353,12 +345,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 19,
    "id": "f4593209",
    "metadata": {},
    "outputs": [],
    "source": [
-    "compiler_config = {\n",
+    "compile_config = {\n",
     "    \"without_quantize\": {\n",
     "        \"parameters\": [{\"permute\": [0, 2, 3, 1]}]\n",
     "    },\n",
@@ -386,56 +378,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 20,
    "id": "3c03f19d",
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Saving the compilation log into /home/yong/.local/state/furiosa/logs/compile-20220507144923-4fvt9v.log\n",
-      "Using furiosa-compiler 0.6.3 (rev: f0e1cf5a8 built at 2022-04-30 05:36:59)\n",
-      "\u001b[2m2022-05-07T05:49:23.949466Z\u001b[0m \u001b[32m INFO\u001b[0m Npu (npu0pe0-1) is being initialized\n",
-      "\u001b[2m2022-05-07T05:49:23.951480Z\u001b[0m \u001b[32m INFO\u001b[0m NuxInner create with pes: [PeId(0)]\n"
-     ]
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "[1/6] 🔍   Compiling from onnx to dfg\n",
-      "Done in 0.07355098s\n",
-      "[2/6] 🔍   Compiling from dfg to ldfg\n",
-      "557372 tactics loaded\n",
-      "\n",
-      "Done in 532.0555s\n",
-      "[3/6] 🔍   Compiling from ldfg to cdfg\n",
-      "Done in 0.00401732s\n",
-      "[4/6] 🔍   Compiling from cdfg to gir\n",
-      "Done in 0.08604555s\n",
-      "[5/6] 🔍   Compiling from gir to lir\n",
-      "Done in 36.338352s\n",
-      "[6/6] 🔍   Compiling from lir to enf\n",
-      "Done in 0.17982386s\n",
-      "✨  Finished in 568.7407s\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u001b[2m2022-05-07T05:58:54.477527Z\u001b[0m \u001b[32m INFO\u001b[0m [Profiler] Program binary notification has been arrived. Cleanup current profile queue data\n",
-      "\u001b[2m2022-05-07T05:59:11.929899Z\u001b[0m \u001b[32m INFO\u001b[0m [Profiler] Received a termination signal.\n",
-      "\u001b[2m2022-05-07T05:59:11.931745Z\u001b[0m \u001b[32m INFO\u001b[0m NPU (npu0pe0-1) has been destroyed\n",
-      "\u001b[2m2022-05-07T05:59:11.932971Z\u001b[0m \u001b[32m INFO\u001b[0m session has been destroyed\n"
+     "ename": "TypeError",
+     "evalue": "create() got an unexpected keyword argument 'compiler_config'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "Cell \u001b[0;32mIn[20], line 3\u001b[0m\n\u001b[1;32m      1\u001b[0m total_predictions \u001b[39m=\u001b[39m \u001b[39m0\u001b[39m\n\u001b[1;32m      2\u001b[0m elapsed_time \u001b[39m=\u001b[39m \u001b[39m0\u001b[39m\n\u001b[0;32m----> 3\u001b[0m \u001b[39mwith\u001b[39;00m furiosa\u001b[39m.\u001b[39;49mruntime\u001b[39m.\u001b[39;49msession\u001b[39m.\u001b[39;49mcreate(\u001b[39m\"\u001b[39;49m\u001b[39myolox_l_quantized.onnx\u001b[39;49m\u001b[39m\"\u001b[39;49m, compiler_config\u001b[39m=\u001b[39;49mcompile_config) \u001b[39mas\u001b[39;00m session:\n\u001b[1;32m      4\u001b[0m     \u001b[39mfor\u001b[39;00m image \u001b[39min\u001b[39;00m islice(glob\u001b[39m.\u001b[39miglob(\u001b[39m\"\u001b[39m\u001b[39mcoco/test2017/*.jpg\u001b[39m\u001b[39m\"\u001b[39m), \u001b[39m1000\u001b[39m):\n\u001b[1;32m      5\u001b[0m         inputs \u001b[39m=\u001b[39m [preproc(cv2\u001b[39m.\u001b[39mimread(image), (\u001b[39m640\u001b[39m, \u001b[39m640\u001b[39m))[\u001b[39m0\u001b[39m][np\u001b[39m.\u001b[39mnewaxis, \u001b[39m.\u001b[39m\u001b[39m.\u001b[39m\u001b[39m.\u001b[39m]]\n",
+      "\u001b[0;31mTypeError\u001b[0m: create() got an unexpected keyword argument 'compiler_config'"
      ]
     }
    ],
    "source": [
     "total_predictions = 0\n",
     "elapsed_time = 0\n",
-    "with furiosa.runtime.session.create(\"yolox_l_quantized.onnx\", compiler_config=compiler_config) as session:\n",
+    "with furiosa.runtime.session.create(\"yolox_l_quantized.onnx\", compile_config=compile_config) as session:\n",
     "    for image in islice(glob.iglob(\"coco/test2017/*.jpg\"), 1000):\n",
     "        inputs = [preproc(cv2.imread(image), (640, 640))[0][np.newaxis, ...]]\n",
     "        start = time.perf_counter_ns()\n",
@@ -454,18 +416,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "4fade41d",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Average Latency: 12.714661311 ms\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "latency = elapsed_time / total_predictions\n",
     "print(f\"Average Latency: {latency / 1_000_000} ms\")"
@@ -496,7 +450,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.5"
+   "version": "3.9.15"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
### Problem
* model compile fails due to one parameter having a typo; 'compiler' instead of 'compile'

### Solution
* make a consistent change everywhere

### Testing
* compile passes and the notebook completes

### Checklist
- [ ] Will this be part of a product update? If yes, please update [Changelog](https://github.com/furiosa-ai/furiosa-sdk-private/blob/main/CHANGELOG.md).
- [ ] Changes are less than 1000 lines (refer to [Pull Request 크기 줄이는 법](https://github.com/furiosa-ai/npu-tools/blob/master/CodingConvention.md#pull-request-%ED%81%AC%EA%B8%B0-%EC%A4%84%EC%9D%B4%EB%8A%94-%EB%B2%95))
- [ ] My code has passed black/isort.
- [ ] I have performed a self-review of my code.
- [ ] All CI checks have passed.
